### PR TITLE
Enable arbitrary loads in App Transport Security

### DIFF
--- a/OwnTracks/OwnTracks/Base.lproj/OwnTracks-Info.plist
+++ b/OwnTracks/OwnTracks/Base.lproj/OwnTracks-Info.plist
@@ -113,7 +113,7 @@
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
-		<false/>
+		<true/>
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>OwnTracks uses your camera on request to create a Card</string>


### PR DESCRIPTION
This should allow connection to non-ssl HTTP endpoints from the iOS app.

I want to make it clear, that I have neither compiled, nor tested whether this is the only change needed to resolve #894 